### PR TITLE
Update cron job schedule

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,7 +1,7 @@
 name: "Forecast"
 on:
   schedule:
-    - cron:  '* * * * *'
+    - cron:  '*/5 * * * *'
 jobs:
   send_current_weather:
     runs-on: "ubuntu-latest"


### PR DESCRIPTION
Update cron job schedule to every 5 minutes. This is the shortest interval for Github actions and is a test to ensure things are working correctly before updating to the actual schedule of once every morning.