### PR TITLE
Update cron schedule for every morning at 8:30

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,7 +1,7 @@
 name: "Forecast"
 on:
   schedule:
-    - cron:  '*/5 * * * *'
+    - cron:  '0 30 8 ? * *'
 jobs:
   send_current_weather:
     runs-on: "ubuntu-latest"


### PR DESCRIPTION
- Updates cron schedule to `0 30 8 ? * *`. This will fire workflow at 8:30am every day, with no care to the day of the month.