### PR TITLE
Hotfix - correct cron schedule for Github actions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,7 +1,7 @@
 name: "Forecast"
 on:
   schedule:
-    - cron:  '0 30 8 ? * *'
+    - cron:  '30 8 * * *'
 jobs:
   send_current_weather:
     runs-on: "ubuntu-latest"


### PR DESCRIPTION
Github supports a specific version of the cron job syntax. Updates to `30 8 * * *` to run the job every day at 8:30am.