### PR TITLE
Update cron job time

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,7 +1,7 @@
 name: "Forecast"
 on:
   schedule:
-    - cron:  '30 8 * * *'
+    - cron:  '30 12 * * *'
 jobs:
   send_current_weather:
     runs-on: "ubuntu-latest"


### PR DESCRIPTION
The initial cron job was set at 8:30 UTC time, which is 4:30 EST. It
would be better to get the current weather at 8:30 EST, so updated the
cron job hour to 12.