### PR TITLE
Update recipient CityID to be dynamic

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,3 +9,10 @@ I wanted to play around a bit more with Golang, in particular handling pointers 
 ## Integrations
 
 Utilizes the [OpenWeather current weather API](https://openweathermap.org/current) for gathering local weather data for my location.
+
+## Development
+In order to run this app in development with all of the environment variables, use the following command:
+
+```
+  DEV=true go run main.go
+```

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,5 @@
 module forecast
 
 go 1.14
+
+require github.com/joho/godotenv v1.3.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,2 @@
+github.com/joho/godotenv v1.3.0 h1:Zjp+RcGpHhGlrMbJzXTrZZPrWj+1vfm90La1wgB6Bhc=
+github.com/joho/godotenv v1.3.0/go.mod h1:7hK45KPybAkOC6peb+G5yklZfMxEjkZhHbwpqxOKXbg=

--- a/mail/send.go
+++ b/mail/send.go
@@ -16,22 +16,35 @@ type Mail struct {
 }
 
 /*
+Recipient is a struct that holds information
+for sending weather emails to the specified people
+*/
+type Recipient struct {
+	Email  string
+	CityID string
+}
+
+/*
 GetRecipients returns a slice of email addresses
 to send forecast data to
 */
-func (m *Mail) GetRecipients() []string {
-	return []string{os.Getenv("JOHN_EMAIL"), os.Getenv("MAGGIE_EMAIL")}
+func (m *Mail) GetRecipients() []*Recipient {
+	var recipients []*Recipient
+
+	recipients = append(recipients, &Recipient{Email: os.Getenv("JOHN_EMAIL"), CityID: "5110302"})
+	recipients = append(recipients, &Recipient{Email: os.Getenv("MAGGIE_EMAIL"), CityID: "5133268"})
+
+	return recipients
 }
 
 /*
 Send uses the base credentials from the Mail struct
-to send a given subject/body from the same user to itself
+to send a given subject/body to the specified recipients
 */
-func (m *Mail) Send(subject, body string) error {
+func (m *Mail) Send(recipients []string, subject, body string) error {
 	msg := []byte("Subject: " + subject + "\r\n" + body)
-	to := m.GetRecipients()
 
-	return smtp.SendMail(m.Host+":587", *m.auth(), m.Username, to, msg)
+	return smtp.SendMail(m.Host+":587", *m.auth(), m.Username, recipients, msg)
 }
 
 func (m *Mail) auth() *smtp.Auth {

--- a/openweather/requests.go
+++ b/openweather/requests.go
@@ -69,9 +69,9 @@ func (r *Requests) GetCurrentWeather() (*CurrentWeather, error) {
 NewRequests sets up a new OpenWeather request struct
 to make requests with that API
 */
-func NewRequests() *Requests {
+func NewRequests(cityID string) *Requests {
 	return &Requests{
 		APIKEY: os.Getenv("OPENWEATHER_API_KEY"),
-		CityID: "5110302",
+		CityID: cityID,
 	}
 }


### PR DESCRIPTION
Each of the recipients lives in a differnet area of NYC, so we want to
update the OpenWeather API call to be specific to those areas. To do
that, a new mail.Recipient struct was created to hold on to email and
cityID information for each recipient.