### PR TITLE
Add OpenWeather OneCall API

### DIFF
--- a/mail/recipients.go
+++ b/mail/recipients.go
@@ -1,0 +1,45 @@
+package mail
+
+import "os"
+
+/*
+Recipient is a struct that holds information
+for sending weather emails to the specified people
+*/
+type Recipient struct {
+	Email    string
+	Location RecipientLocation
+}
+
+type RecipientLocation struct {
+	CityID string
+	Lat    string
+	Long   string
+}
+
+/*
+GetRecipients returns a slice of email addresses
+to send forecast data to
+*/
+func (m *Mail) GetRecipients() []*Recipient {
+	var recipients []*Recipient
+
+	recipients = append(recipients, &Recipient{
+		Email: os.Getenv("JOHN_EMAIL"),
+		Location: RecipientLocation{
+			CityID: "5110302",
+			Lat:    "40.650101",
+			Long:   "-73.949577",
+		},
+	})
+	recipients = append(recipients, &Recipient{
+		Email: os.Getenv("MAGGIE_EMAIL"),
+		Location: RecipientLocation{
+			CityID: "5133268",
+			Lat:    "40.7001",
+			Long:   "-73.799583",
+		},
+	})
+
+	return recipients
+}

--- a/mail/send.go
+++ b/mail/send.go
@@ -16,28 +16,6 @@ type Mail struct {
 }
 
 /*
-Recipient is a struct that holds information
-for sending weather emails to the specified people
-*/
-type Recipient struct {
-	Email  string
-	CityID string
-}
-
-/*
-GetRecipients returns a slice of email addresses
-to send forecast data to
-*/
-func (m *Mail) GetRecipients() []*Recipient {
-	var recipients []*Recipient
-
-	recipients = append(recipients, &Recipient{Email: os.Getenv("JOHN_EMAIL"), CityID: "5110302"})
-	recipients = append(recipients, &Recipient{Email: os.Getenv("MAGGIE_EMAIL"), CityID: "5133268"})
-
-	return recipients
-}
-
-/*
 Send uses the base credentials from the Mail struct
 to send a given subject/body to the specified recipients
 */

--- a/main.go
+++ b/main.go
@@ -21,9 +21,15 @@ func main() {
 	recipients := mail.NewMail().GetRecipients()
 
 	for _, r := range recipients {
-		openWeatherRequests := openweather.NewRequests(r.CityID)
+		openWeatherRequests := openweather.NewRequests()
 
-		currentWeather, err := openWeatherRequests.GetCurrentWeather()
+		currentWeather, err := openWeatherRequests.GetCurrentWeather(r.Location)
+		if err != nil {
+			fmt.Println(err)
+			return
+		}
+
+		oneCallWeather, err := openWeatherRequests.GetOneCallWeather(r.Location)
 		if err != nil {
 			fmt.Println(err)
 			return
@@ -31,7 +37,9 @@ func main() {
 
 		formatter := openweather.NewFormat()
 
-		err = mail.NewMail().Send([]string{r.Email}, "Weather Today", formatter.FormatCurrentWeather(currentWeather))
+		emailBody := formatter.FormatCurrentWeather(currentWeather) + "\n" + formatter.FormatOneCallWeather(oneCallWeather)
+
+		err = mail.NewMail().Send([]string{r.Email}, "Weather Today", emailBody)
 		if err != nil {
 			log.Fatal(err)
 		}

--- a/openweather/format.go
+++ b/openweather/format.go
@@ -1,6 +1,9 @@
 package openweather
 
-import "fmt"
+import (
+	"fmt"
+	"time"
+)
 
 /*
 Format is an empty struct with methods
@@ -25,12 +28,66 @@ func (f *Format) FormatCurrentWeather(currentWeather *CurrentWeather) string {
 	currentDesc := fmt.Sprintf("With a current temp of %vF degrees, and a high of %vF degrees.", temp, tempMax)
 	feelsDesc := fmt.Sprintf("It feels like %vF degrees.", feelsLike)
 
-	return fmt.Sprintf(`
-		%v
-		%v
-		%v
-		%v
-	`, open, desc, currentDesc, feelsDesc)
+	return fmt.Sprintf("\n%v\n%v\n%v\n%v\n", open, desc, currentDesc, feelsDesc)
+}
+
+/*
+FormatOneCallWeather uses a oneCallWeather struct
+to format the data into human-readable text
+*/
+func (f *Format) FormatOneCallWeather(oneCallWeather *OneCallWeather) string {
+	var hourly string
+	var daily string
+
+	now := time.Now().Hour()
+	hoursToEOD := 24 - now
+	hourlyCount := 0
+
+	for hourlyCount < hoursToEOD {
+		h := oneCallWeather.Hourly[hourlyCount]
+
+		hour := formatHour(h.DT)
+		currentHour := fmt.Sprintf("%v: %vF degrees, %v", hour, h.Temp, h.Weather[0].Description)
+
+		hourly = fmt.Sprintf("%s\n", hourly+currentHour)
+
+		hourlyCount++
+	}
+
+	dailyCount := 1
+	dailyCutOff := 5
+
+	for dailyCount <= dailyCutOff {
+		d := oneCallWeather.Daily[dailyCount]
+
+		day := formatDay(d.DT)
+		currentDay := fmt.Sprintf("%s: %vF degrees, %v", day, d.Temp.Day, d.Weather[0].Description)
+
+		daily = fmt.Sprintf("%s\n", daily+currentDay)
+
+		dailyCount++
+	}
+
+	return fmt.Sprintf("The rest of the day:\n%s\nThe next 5 days:\n%s", hourly, daily)
+}
+
+func formatHour(unixTime int64) string {
+	hour := time.Unix(unixTime, 0).Hour()
+
+	if hour <= 12 {
+		return fmt.Sprintf("%vam", hour)
+	}
+
+	return fmt.Sprintf("%vpm", hour-12)
+}
+
+func formatDay(unixTime int64) string {
+	t := time.Unix(unixTime, 0)
+	day := t.Day()
+	month := t.Month()
+	weekday := t.Weekday()
+
+	return fmt.Sprintf("%s %s %v", weekday, month, day)
 }
 
 /*


### PR DESCRIPTION
**Description**
- Add `openweather.GetOneCallWeather` request to ping the OpenWeather OneCall API
- Add structs to unmarshall JSON for OneCall API request
- Add `Lat` and `Long` values to each `Recipient`, for use in the OneCall API request
- Move the `mail.GetRecipients` function to its own file
- Add `formatter.FormatOneCallWeather` to help with formatting the response from the OneCall API to a human readable message

**Context**
This commit adds the OpenWeather OneCall API, which provides detailed
weather information for the current day on an hourly basis, as well as
weather information for the next week.