### PR TITLE
Update noon time format

### DIFF
--- a/openweather/format.go
+++ b/openweather/format.go
@@ -74,7 +74,11 @@ func (f *Format) FormatOneCallWeather(oneCallWeather *OneCallWeather) string {
 func formatHour(unixTime int64) string {
 	hour := time.Unix(unixTime, 0).Hour()
 
-	if hour <= 12 {
+	if hour == 12 {
+		return fmt.Sprintf("12pm")
+	}
+
+	if hour < 12 {
 		return fmt.Sprintf("%vam", hour)
 	}
 


### PR DESCRIPTION
Previously, the noon hour was being formatted as "12am", because of
incorrect logic to use the "am" suffix for all hours less than or equal
to 12. This commit updates that logic to ensure that noon is formatted
as "12pm".